### PR TITLE
fix(users): Bloquear modificación de 'document' en actualizaciones de usuario

### DIFF
--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -284,6 +284,18 @@ class AdminUserUpdateAPIView(generics.RetrieveUpdateAPIView):
     
     def patch(self, request, *args, **kwargs):
         """Maneja actualizaciones parciales con formato de respuesta consistente"""
+        
+        # Validación para el documento
+        if 'document' in request.data:
+            return Response(
+                {
+                    'status': 'error',
+                    'message': 'Modificación de documento no permitida',
+                    'details': 'El documento de identidad no puede ser modificado'
+                },
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
         response = super().patch(request, *args, **kwargs)
         
         if response.status_code == status.HTTP_200_OK:


### PR DESCRIPTION
### Cambios realizados
- Se añadió validación en `AdminUserUpdateAPIView` para bloquear la modificación del campo `document` en operaciones de actualización (PATCH/PUT).
- Esto evita la creación de usuarios duplicados al intentar modificar el documento.

### Contexto
El campo `document` es el identificador único (PK) de los usuarios, por lo que no debería ser modificable después de la creación. Sin esta validación, al intentar actualizar un usuario enviando un nuevo valor para `document`, se creaba un nuevo usuario con ese documento, lo cual es un comportamiento no deseado.

### Solución implementada
- Se añadió una validación en el método `patch` de `AdminUserUpdateAPIView` que verifica si el campo `document` está presente en el request.
- Si se detecta un intento de modificación, se devuelve un error 400 con un mensaje claro.