### PR TITLE
feat: Implementar visualización de predios junto a un sistema de permisos

### DIFF
--- a/backend/plots_lots/permissions.py
+++ b/backend/plots_lots/permissions.py
@@ -1,0 +1,27 @@
+from rest_framework.permissions import BasePermission
+
+class IsAdminUser(BasePermission):
+    """
+    Permiso personalizado para permitir solo a usuarios administradores.
+    """
+    def has_permission(self, request, view):
+        return bool(request.user and request.user.is_staff)
+
+class IsOwnerOrAdmin(BasePermission):
+    """
+    Permiso personalizado para permitir a usuarios ver solo sus propios predios,
+    mientras que los administradores pueden ver todos.
+    """
+    def has_permission(self, request, view):
+        # Si es una lista (GET al endpoint principal), solo permitir a admins
+        if view.action == 'list':
+            return bool(request.user and request.user.is_staff)
+        # Para otras acciones, permitir si el usuario está autenticado
+        return bool(request.user and request.user.is_authenticated)
+
+    def has_object_permission(self, request, view, obj):
+        # Permitir acceso si el usuario es admin o es el dueño del predio
+        return bool(
+            request.user.is_staff or
+            obj.owner.document == request.user.document
+        )

--- a/backend/plots_lots/urls.py
+++ b/backend/plots_lots/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from .views import PlotViewSet
 urlpatterns = [
     path('register', PlotViewSet.as_view({'post': 'create'}),name='registrar-predio' ),
+    path('list', PlotViewSet.as_view({'get': 'list'}), name='listar-predios'),
     # Actualizar un predio 
     path('<str:pk>/update/', PlotViewSet.as_view({'put': 'update', 'patch': 'partial_update'}), name='actualizar-predio'),
     path('<str:pk>/inhabilitar/', PlotViewSet.as_view({'post': 'inactive'}), name='inhabilitar-predio'),

--- a/backend/plots_lots/views.py
+++ b/backend/plots_lots/views.py
@@ -4,11 +4,21 @@ from rest_framework.response import Response
 from rest_framework import status
 from .models import Plot
 from .serializers import PlotSerializer
+from .permissions import IsOwnerOrAdmin
 
 class PlotViewSet(viewsets.ModelViewSet):
     queryset = Plot.objects.all()
     serializer_class = PlotSerializer
-    permission_classes = [IsAuthenticated]  # Solo usuarios autenticados pueden acceder
+    permission_classes = [IsAuthenticated, IsOwnerOrAdmin]
+
+    def get_queryset(self):
+        """
+        Retorna todos los predios para administradores,
+        o solo los predios del usuario para usuarios normales.
+        """
+        if self.request.user.is_staff:
+            return Plot.objects.all()
+        return Plot.objects.filter(owner=self.request.user)
 
     def perform_update(self, serializer):
         """ Validar que el usuario no envíe los mismos datos al actualizar """


### PR DESCRIPTION
# Implementación de Sistema de Permisos para Visualización de Predios

## 🎯 Objetivo
Implementar un sistema de permisos robusto que restrinja el acceso a la información de predios basado en roles de usuario, garantizando que solo los administradores puedan ver todos los predios mientras que los usuarios regulares solo puedan acceder a sus propios predios.

## 📝 Cambios Realizados
### 1. Nuevo Sistema de Permisos (`plots-lots/permissions.py`)
- Creación de clase `IsAdminUser`:
  - Verifica si el usuario tiene permisos de administrador (`is_staff = True`)
  - Controla el acceso a funcionalidades administrativas

- Implementación de clase `IsOwnerOrAdmin`:
  - Gestiona permisos a nivel de objeto
  - Permite acceso completo a administradores
  - Restringe usuarios regulares a sus propios predios
  - Implementa lógica específica para diferentes acciones (list, retrieve, update)

### 2. Modificaciones en Vistas (`plots-lots/views.py`)
- Actualización del `PlotViewSet`:
  - Integración de nuevos permisos: `[IsAuthenticated, IsOwnerOrAdmin]`
  - Implementación de `get_queryset()` personalizado:
    ```python
    def get_queryset(self):
        if self.request.user.is_staff:
            return Plot.objects.all()
        return Plot.objects.filter(owner=self.request.user)
    ```
  - Filtrado automático de predios basado en el rol del usuario

## ✅ Pruebas Realizadas
### Pruebas con Usuario Administrador
- **Resultado**: Acceso exitoso al listado completo de predios
- **Endpoint**: `GET /api/plot-lot/list`
- **Respuesta**: Lista completa de predios en el sistema

### Pruebas con Usuario Regular
- **Resultado**: Acceso denegado al listado completo
- **Endpoint**: `GET /api/plot-lot/list`
- **Respuesta**: Mensaje de permiso denegado

## 🔄 Pasos para Probar
1. Iniciar sesión como administrador
2. Acceder a `GET /api/plot-lot/list`
3. Verificar acceso a todos los predios
4. Cambiar a usuario regular
5. Intentar acceder al mismo endpoint
6. Verificar que el acceso está correctamente restringido