### PR TITLE
Implementación del RF29, RF30 y RF39, junto a la reestructura de permisos y vistas para Lotes con reutilización de código

### DIFF
--- a/backend/plots_lots/permissions.py
+++ b/backend/plots_lots/permissions.py
@@ -3,28 +3,39 @@ from rest_framework.permissions import BasePermission, IsAdminUser
 class IsOwnerOrAdmin(BasePermission):
     """
     Permiso personalizado que:
-    1. Para acciones de lista (GET /plots):
-       - Permite acceso solo a administradores
-    2. Para acciones sobre predios específicos:
+    1. Para acciones de lista (GET /plots o /lots):
+       - Permite acceso a administradores para ver todo
+       - Permite a usuarios ver sus propios recursos
+    2. Para acciones de lectura (GET):
        - Permite acceso a administradores
-       - Permite acceso a dueños de sus propios predios
-       - Deniega acceso a otros usuarios
+       - Permite acceso a dueños para ver sus propios recursos
+    3. Para acciones de escritura (POST, PUT, PATCH, DELETE):
+       - Permite acceso solo a administradores
     """
     def has_permission(self, request, view):
         # Verificar autenticación básica
         if not request.user or not request.user.is_authenticated:
             return False
             
-        # Para listar predios, solo permitir admins
-        if view.action == 'list':
+        # Para acciones de escritura, solo admins
+        if request.method not in ['GET', 'HEAD', 'OPTIONS']:
             return IsAdminUser().has_permission(request, view)
             
-        # Para otras acciones, permitir usuarios autenticados
+        # Para acciones de lectura (incluyendo list), permitir usuarios autenticados
         return True
 
     def has_object_permission(self, request, view, obj):
-        # Permitir acceso si es admin o dueño del predio
-        return (
-            IsAdminUser().has_permission(request, view) or 
-            obj.owner.document == request.user.document
-        )
+        # Para acciones de escritura, solo admins
+        if request.method not in ['GET', 'HEAD', 'OPTIONS']:
+            return IsAdminUser().has_permission(request, view)
+            
+        # Para acciones de lectura
+        if IsAdminUser().has_permission(request, view):
+            return True
+            
+        # Para lotes, verificar el dueño del predio asociado
+        if hasattr(obj, 'plot'):
+            return obj.plot.owner.document == request.user.document
+            
+        # Para predios, verificar el dueño directamente
+        return obj.owner.document == request.user.document

--- a/backend/plots_lots/serializers.py
+++ b/backend/plots_lots/serializers.py
@@ -1,8 +1,9 @@
 from rest_framework import serializers
-from .models import Plot,Lot,SoilType
+from .models import Plot, Lot, SoilType
 from users.models import CustomUser
-from rest_framework.exceptions import NotFound
+
 class PlotSerializer(serializers.ModelSerializer):
+    """Serializer base para predios con campos básicos."""
     owner = serializers.PrimaryKeyRelatedField(
         queryset=CustomUser.objects.all(),
         error_messages={'does_not_exist': "El usuario asignado no está registrado"}
@@ -10,60 +11,51 @@ class PlotSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Plot
-        fields = ['id_plot', 'owner', 'plot_name', 'latitud', 'longitud', 'plot_extension', 'registration_date','is_activate']
-        read_only_fields = ['id_plot', 'registration_date','is_activate']
+        fields = ['id_plot', 'owner', 'plot_name', 'latitud', 'longitud', 'plot_extension', 'registration_date', 'is_activate']
+        read_only_fields = ['id_plot', 'registration_date', 'is_activate']
 
-    
     def validate(self, data):
         """Validación personalizada para evitar duplicados en la georeferenciación."""
         latitud = data.get('latitud')
         longitud = data.get('longitud')
 
-           # Obtener la instancia actual si está disponible
-        instance = self.instance  
-
-        # Verificar si la geolocalización ya está asignada a otro predio (excluyendo el actual)
+        instance = self.instance
         if Plot.objects.exclude(id_plot=instance.id_plot if instance else None).filter(latitud=latitud, longitud=longitud).exists():
             raise serializers.ValidationError("La georeferenciación ya está asignada a otro predio.")
-
         return data
-    
+
 class LotSerializer(serializers.ModelSerializer):
+    """Serializer base para lotes con campos básicos."""
     class Meta:
         model = Lot
-        fields = ['id_lot', 'plot', 'crop_type', 'crop_variety', 'soil_type', 'is_activate','registration_date']
-        read_only_fields = ['id_lot']  # id_lot se genera automáticamente, no debe ser enviado por el usuario
+        fields = ['id_lot', 'plot', 'crop_type', 'crop_variety', 'soil_type', 'is_activate', 'registration_date']
+        read_only_fields = ['id_lot', 'registration_date', 'is_activate']
 
     def validate_plot(self, value):
-        """
-        Validación personalizada para el campo 'plot'.
-        Asegura que el predio exista en la base de datos.
-        """
-        if not Plot.objects.filter(id_plot=value.id_plot).exists():
-            raise serializers.ValidationError("El predio no existe.")
+        """Valida que el predio exista y esté activo."""
+        if not Plot.objects.filter(id_plot=value.id_plot, is_activate=True).exists():
+            raise serializers.ValidationError("El predio no existe o está inactivo.")
         return value
 
     def validate_soil_type(self, value):
-        """
-        Validación personalizada para el campo 'soil_type'.
-        Asegura que el tipo de suelo exista en la base de datos.
-        """
+        """Valida que el tipo de suelo exista."""
         if not SoilType.objects.filter(id=value.id).exists():
             raise serializers.ValidationError("El tipo de suelo no existe.")
         return value
 
-class LotActivationSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Lot
-        fields = ['is_activate']  # Solo permitimos actualizar este campo    
+class PlotDetailSerializer(PlotSerializer):
+    """Serializer extendido para ver detalles de predios, incluyendo sus lotes."""
+    lotes = LotSerializer(many=True, read_only=True, source='lot_set')
+    owner_name = serializers.CharField(source='owner.get_full_name', read_only=True)
 
-class PlotDetailSerializer(serializers.ModelSerializer):
-    lotes = LotSerializer(many=True, read_only=True)  # Incluye los lotes relacionados
+    class Meta(PlotSerializer.Meta):
+        fields = PlotSerializer.Meta.fields + ['lotes', 'owner_name']
 
-    class Meta:
-        model = Plot
-        fields = [
-            'id_plot', 'owner', 'plot_name', 'latitud', 'longitud', 'plot_extension',
-            'registration_date', 'is_activate', 'lotes'
-        ]        
-        
+class LotDetailSerializer(LotSerializer):
+    """Serializer extendido para ver detalles de lotes, incluyendo información del predio."""
+    plot_name = serializers.CharField(source='plot.plot_name', read_only=True)
+    plot_owner = serializers.CharField(source='plot.owner.get_full_name', read_only=True)
+    soil_type_name = serializers.CharField(source='soil_type.name', read_only=True)
+
+    class Meta(LotSerializer.Meta):
+        fields = LotSerializer.Meta.fields + ['plot_name', 'plot_owner', 'soil_type_name']

--- a/backend/plots_lots/urls.py
+++ b/backend/plots_lots/urls.py
@@ -1,15 +1,20 @@
 from django.urls import path
-from .views import PlotViewSet,LotCreateView,ActivateLotView, DeactivateLotView,PlotDetailView
+from .views import PlotViewSet, LotViewSet
+
 urlpatterns = [
     # Rutas para predios
-    path('plots/register', PlotViewSet.as_view({'post': 'create'}),name='registrar-predio' ),
+    path('plots/register', PlotViewSet.as_view({'post': 'create'}), name='registrar-predio'),
     path('plots/list', PlotViewSet.as_view({'get': 'list'}), name='listar-predios'),
-    path('plots/<str:pk>/update', PlotViewSet.as_view({'put': 'update', 'patch': 'partial_update'}), name='actualizar-predio'),
-    path('plots/<str:pk>/inhabilitar', PlotViewSet.as_view({'post': 'inactive'}), name='inhabilitar-predio'),
-    path('plots/<str:pk>/habilitar', PlotViewSet.as_view({'post': 'active'}), name='habilitar-predio'),
-    path('plot/<str:id_plot>/', PlotDetailView.as_view(), name='plot-detail'),
+    path('plots/<str:id_plot>', PlotViewSet.as_view({'get': 'retrieve'}), name='detalle-predio'),
+    path('plots/<str:id_plot>/update', PlotViewSet.as_view({'put': 'update', 'patch': 'partial_update'}), name='actualizar-predio'),
+    path('plots/<str:id_plot>/inhabilitar', PlotViewSet.as_view({'post': 'inactive'}), name='inhabilitar-predio'),
+    path('plots/<str:id_plot>/habilitar', PlotViewSet.as_view({'post': 'active'}), name='habilitar-predio'),
+    
     # Rutas para lotes
-    path('lots/register', LotCreateView.as_view(), name='lot-create'),
-    path('lots/<str:id_lot>/activate', ActivateLotView.as_view(), name='activate-lot'),
-    path('lots/<str:id_lot>/desactivate', DeactivateLotView.as_view(), name='deactivate-lot')    
+    path('lots/register', LotViewSet.as_view({'post': 'create'}), name='lot-create'),
+    path('lots/list', LotViewSet.as_view({'get': 'list'}), name='lot-list'),
+    path('lots/<str:id_lot>', LotViewSet.as_view({'get': 'retrieve'}), name='detalle-lote'),
+    path('lots/<str:id_lot>/update', LotViewSet.as_view({'put': 'update', 'patch': 'partial_update'}), name='lot-update'),
+    path('lots/<str:id_lot>/desactivate', LotViewSet.as_view({'post': 'inactive'}), name='deactivate-lot'),
+    path('lots/<str:id_lot>/activate', LotViewSet.as_view({'post': 'active'}), name='activate-lot'),
 ]


### PR DESCRIPTION
## Descripción
Refactorización del módulo `plots_lots` para:
- Se reutilizó código entre Predios y Lotes mediante la clase base `BaseModelViewSet`.
- Se implementó permisos granulares (`IsOwnerOrAdmin`) con verificación de propiedad.
- Se mejoró serializadores con relaciones anidadas y validaciones.
- Se actualizó URLs para consistencia en endpoints.

## Cambios clave
- **Archivos modificados**:
  - `permissions.py`: Lógica de permisos unificada.
  - `views.py`: Clase base abstracta y herencia.
  - `serializers.py`: Serializadores detallados.
  - `urls.py`: Rutas estandarizadas.
- **Impacto**:
  - Usuarios normales solo ven recursos propios.
  - Admins tienen control total.
  - Menos duplicación de código.

## Checklist
- [x] Testeado localmente con usuarios Admin y Normales.
- [x] Documentación actualizada.