### PR TITLE
feat(Django_Admin): Agregar tipos de cultivo y personalizar demás campos

### DIFF
--- a/backend/iot/models.py
+++ b/backend/iot/models.py
@@ -21,6 +21,10 @@ class DeviceType(models.Model):
 
     def __str__(self):
         return f"{self.name} ({self.device_id})"
+    
+    class Meta:
+        verbose_name = "Tipo de dispositivo IoT"
+        verbose_name_plural = "Tipos de dispositivos IoT"
 
 # Constantes para tipos de válvulas
 VALVE_48_ID = '05' # ID para válvula de 48"

--- a/backend/plots_lots/admin.py
+++ b/backend/plots_lots/admin.py
@@ -1,21 +1,30 @@
 from django.contrib import admin
-from .models import Plot,Lot,SoilType
-
+from .models import Plot, Lot, SoilType, CropType
 
 # Register your models here.
 @admin.register(Plot)
 class PlotAdmin(admin.ModelAdmin):
     list_display = ('id_plot', 'owner', 'plot_name', 'latitud', 'longitud', 'plot_extension', 'registration_date', 'is_activate')
-    search_fields = ('plot_name', 'owner')
+    search_fields = ('id_plot', 'plot_name', 'owner')
     list_filter = ('registration_date',)
     ordering = ('registration_date',)
-    readonly_fields = ('id_plot',)  # 🔹 Agregar esto
+    readonly_fields = ('id_plot',)
+
 @admin.register(SoilType)
 class SoilTypeAdmin(admin.ModelAdmin):
+    list_display = ('id', 'name')
+    search_fields = ('id', 'name')
+    ordering = ('id',)
+
+@admin.register(CropType)
+class CropTypeAdmin(admin.ModelAdmin):
     list_display = ('id','name')
+    search_fields = ('id', 'name')
+    ordering = ('id',)
 
 @admin.register(Lot)
 class LotAdmin(admin.ModelAdmin):
-    list_display = ('id_lot','plot', 'crop_type', 'crop_variety', 'soil_type','registration_date','is_activate')
+    list_display = ('id_lot', 'plot', 'crop_type', 'crop_variety', 'soil_type', 'registration_date', 'is_activate')
     list_filter = ('plot', 'soil_type')
-    search_fields = ('crop_type', 'crop_variety')    
+    search_fields = ('id_lot', 'crop_type', 'crop_variety')
+    ordering = ('registration_date',)

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -98,6 +98,8 @@ class CustomUser(AbstractUser):
     objects = UserManager()
     
     class Meta:
+        verbose_name = "Usuario"
+        verbose_name_plural = "Usuarios"
         permissions = [
             ("can_toggle_is_active", "Puede cambiar el estado de is_active"),
             ("can_toggle_is_registered", "Puede cambiar el estado de is_registered"),
@@ -157,7 +159,11 @@ class DocumentType(models.Model):
     typeName = models.CharField(max_length=50, verbose_name="Nombre del Tipo de Documento")
 
     def __str__(self):
-        return f"{self.documentTypeId} - {self.typeName}"  
+        return f"{self.documentTypeId} - {self.typeName}"
+    
+    class Meta:
+        verbose_name = "Tipo de documento"
+        verbose_name_plural = "Tipos de documento"
 
 class PersonType(models.Model):
     """
@@ -169,6 +175,10 @@ class PersonType(models.Model):
 
     def __str__(self):
         return f"{self.personTypeId} - {self.typeName}"
+    
+    class Meta:
+        verbose_name = "Tipos de persona"
+        verbose_name_plural = "Tipos de persona"
     
 class LoginRestriction(models.Model):
     user = models.ForeignKey(


### PR DESCRIPTION
Para el apartado de Django Admin se agregó el tipo de cultivo, así como "españolizar" atributos de la interfaz principal y agregar filtros de búsqueda y de orden.