### PR TITLE
fix(valve): Corregir validaciones que no tomaban en cuenta la instancia actual del objeto

### DIFF
--- a/backend/iot/models.py
+++ b/backend/iot/models.py
@@ -112,6 +112,8 @@ class IoTDevice(models.Model):
                     id_plot=self.id_plot,
                     id_lot__isnull=True
                 )
+                    if self.iot_id:  # Si es una actualización, excluir el dispositivo actual
+                        queryset = queryset.exclude(iot_id=self.iot_id)
 
                     if queryset.exists():
                             raise ValidationError(
@@ -125,6 +127,8 @@ class IoTDevice(models.Model):
                     id_lot=self.id_lot,
                     id_plot__isnull=True
                 )
+                    if self.iot_id:  # Si es una actualización, excluir el dispositivo actual
+                        queryset = queryset.exclude(iot_id=self.iot_id)
 
                     if queryset.exists():
                             raise ValidationError(


### PR DESCRIPTION
Cada vez que se pretendía actualizar un dato de la válvula de 48" o de cualquier otra válvula de 4", el sistema lanzaba un error 500, debido a que, desde el modelo, la validación para la actualización de estas válvulas no tomaba en cuenta la instancia actual del objeto. Así que, se añadió estas validaciones para las válvulas.