### PR TITLE
hotfix(valve): Corregir validación de actual_flow y demás errores

### DIFF
--- a/backend/iot/models.py
+++ b/backend/iot/models.py
@@ -27,8 +27,8 @@ class DeviceType(models.Model):
         verbose_name_plural = "Tipos de dispositivos IoT"
 
 # Constantes para tipos de válvulas
-VALVE_48_ID = '05' # ID para válvula de 48"
-VALVE_4_ID = '06' # ID para válvula de 4"
+VALVE_48_ID = '6' # ID para válvula de 48"
+VALVE_4_ID = '7' # ID para válvula de 4"
 
 class IoTDevice(models.Model):
     iot_id = models.CharField(max_length=7, primary_key=True, editable=False)  # Formato XX-YYYY
@@ -76,12 +76,6 @@ class IoTDevice(models.Model):
 
         # Validar que el dispositivo sea una válvula
         if self.device_type_id in [VALVE_48_ID, VALVE_4_ID]:
-            # Validar que actual_flow esté presente para válvulas
-            if self.actual_flow is None:
-                raise ValidationError({
-                    "actual_flow": "El caudal actual es requerido para válvulas."
-                })
-            
             # Validaciones específicas para válvula de 48"
             if self.device_type_id == VALVE_48_ID:
                 # Verificar que no exista otra válvula de 48"
@@ -114,23 +108,20 @@ class IoTDevice(models.Model):
                 )
                     if self.iot_id:  # Si es una actualización, excluir el dispositivo actual
                         queryset = queryset.exclude(iot_id=self.iot_id)
-
-                    if queryset.exists():
+                    if queryset.exists(): # Evaluar si ya existe una válvula de 4" asignada al predio
                             raise ValidationError(
                                 "Ya existe una válvula asignada a este predio."
                             )
                 
                 # Validar que no haya más de una válvula de 4" por lote
-                if self.id_lot and not self.id_plot:
+                if self.id_lot:
                     queryset = IoTDevice.objects.filter(
                     device_type_id=VALVE_4_ID,
-                    id_lot=self.id_lot,
-                    id_plot__isnull=True
+                    id_lot=self.id_lot
                 )
                     if self.iot_id:  # Si es una actualización, excluir el dispositivo actual
                         queryset = queryset.exclude(iot_id=self.iot_id)
-
-                    if queryset.exists():
+                    if queryset.exists(): # Evaluar si ya existe una válvula de 4" asignada al lote
                             raise ValidationError(
                                 "Ya existe una válvula asignada a este lote."
                             )

--- a/backend/iot/serializers.py
+++ b/backend/iot/serializers.py
@@ -45,12 +45,6 @@ class IoTDeviceSerializer(serializers.ModelSerializer):
 
         # Validar que el dispositivo sea una válvula
         if device_type.device_id in [VALVE_48_ID, VALVE_4_ID]:
-            # Validar que actual_flow esté presente para válvulas
-            if actual_flow is None:
-                raise serializers.ValidationError({
-                    "actual_flow": "El caudal actual es requerido para válvulas."
-                })
-
             # Validaciones específicas para válvula de 48"
             if device_type.device_id == VALVE_48_ID:
                 # Verificar que no exista otra válvula de 48"
@@ -80,25 +74,23 @@ class IoTDeviceSerializer(serializers.ModelSerializer):
                     id_plot=id_plot,
                     id_lot__isnull=True
                 )
+
                     if self.instance:  # Si es una actualización, excluir el dispositivo actual
                         queryset = queryset.exclude(iot_id=self.instance.iot_id)
-
-                    if queryset.exists():
+                    if queryset.exists(): # Evaluar si ya existe una válvula de 4" asignada al predio
                         raise serializers.ValidationError(
                             "Ya existe una válvula asignada a este predio."
                         )
-                
+            
                 # Validar que no haya más de una válvula de 4" por lote
-                if id_lot and not id_plot:
+                if id_lot:
                     queryset = IoTDevice.objects.filter(
                     device_type_id=VALVE_4_ID,
-                        id_lot=id_lot,
-                        id_plot__isnull=True
+                    id_lot=id_lot
                 )
                     if self.instance:  # Si es una actualización, excluir el dispositivo actual
                         queryset = queryset.exclude(iot_id=self.instance.iot_id)
-
-                    if queryset.exists():
+                    if queryset.exists(): # Evaluar si ya existe una válvula de 4" asignada al lote
                         raise serializers.ValidationError(
                             "Ya existe una válvula asignada a este lote."
                         )


### PR DESCRIPTION
Problemas:
- El caudal actual (actual_flow) se solicitaba al momento de crear y/o actualizar una válvula, lo cual generaba problemas debido a que el caudal actual no se registra/actualiza desde el apartado de "Registrar Dispositivo IoT" y "Actualizar Dispositivo IoT", generando el error: "El caudal actual es requerido para válvulas."
- Al registrar o actualizar un dispositivo IoT, no se activaban ciertas validaciones correspondientes. Esto debido a dos razones: 1. Error de indentación; 2. Condicionales y filtros que generaban inconsistencias en la consulta de las validaciones.

Correciones:
- El caudal actual (actual_flow) ya no es obligatorio al momento de crear o actualizar una válvula.
- Las identaciones ya están en los niveles que les corresponden.
- Se modificó condicionales y filtros que generaban inconsistencias en la lógica.