### PR TITLE
hotfix(endpoints-billing): Corregir implementación de endpoints

### DIFF
--- a/backend/API/urls.py
+++ b/backend/API/urls.py
@@ -27,5 +27,5 @@ urlpatterns = [
     path("api/iot/",include("iot.urls"), name="app-iot"),
     path("api/admin/",include("API.groups_permissions.urls"),name="Permisos_roles"),
     path("api/caudal/",include("caudal.urls"),name="app-caudal"),
-    path("api/billing/", include("billing.bill.urls")), 
+    path("api/billing/", include("billing.urls")), 
 ]

--- a/backend/billing/bill/urls.py
+++ b/backend/billing/bill/urls.py
@@ -1,7 +1,0 @@
-from django.urls import path
-from . import views
-
-urlpatterns = [
-    path('user/bills', views.UserBillListView.as_view(), name='user-bills'),  # Facturas de un usuario
-    path('admin/bills', views.AdminBillListView.as_view(), name='admin-bills'),  # Todas las facturas para admin
-]

--- a/backend/billing/urls.py
+++ b/backend/billing/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
 from .views import RatesAndCompanyView
+from .bill.views import UserBillListView, AdminBillListView
 
 urlpatterns = [
-    path('rates-company', RatesAndCompanyView.as_view(), name='rates-company'),
+    path('rates-company', RatesAndCompanyView.as_view(), name='rates-company'), # Listar y actualizar tarifas y empresa
+    path('user/bills', UserBillListView.as_view(), name='user-bills'),  # Facturas de un usuario
+    path('admin/bills', AdminBillListView.as_view(), name='admin-bills'),  # Todas las facturas para admin
 ]


### PR DESCRIPTION
# Problemática:
- La opción de listar y de actualizar predios no funciona, y lanza un Status: 404 Not Found.
![image](https://github.com/user-attachments/assets/882d7390-85e0-4b54-b48f-46816fad219e)

# Análisis:
En el último commit de Johan Mosquera (@Kira1974), él creó un nuevo archivo urls.py dentro de la carpeta bill colocando los endpoints correspondientes al modelo Bill (Factura). Después, en el archivo API/urls.py modificó la ruta de detección de "billing.urls" a "billing.bill.urls". Esto ocasionó que Django reenfocara la ruta de detección a bill/urls.py, y provocó que los endpoints que estaban en el archivo urls.py raíz de la carpeta Billing no se tomaran en cuenta; debido a esto, la funcionalidad de listar y actualizar las tarifas y datos de empresa quedó inútil, porque Django no detecta esos endpoints.

# Solución
- Se cambió el archivo API/urls.py como estaba anteriormente, con su ruta de detección hacia "billing.urls".
- Se trasladaron las urls de la funcionalidad de Bill (Factura) desde billing/bill/urls.py hacia billing/urls.py.
- Se eliminó el archivo billing/bill/urls.py.