### PR TITLE
hotfix(flow-change-request): Adaptar la lógica para que el usuario so…

### DIFF
--- a/backend/communication/admin.py
+++ b/backend/communication/admin.py
@@ -9,5 +9,5 @@ class FlowChangeRequestAdmin(admin.ModelAdmin):
     )
     list_filter = ('status', 'created_at', 'reviewed_at')
     search_fields = ('user__username', 'lot__id_lot', 'plot__plot_name')
-    readonly_fields = ('lot', 'plot', 'created_at', 'reviewed_at')
+    readonly_fields = ('device', 'plot', 'created_at', 'reviewed_at')
     date_hierarchy = 'created_at'


### PR DESCRIPTION
# Corrección de lógica para solicitudes de cambio de caudal por lote
Actualizar la lógica de creación de solicitudes de cambio de caudal (FlowChangeRequest) para que el usuario solo deba seleccionar el lote. El sistema ahora:
- Asigna automáticamente el dispositivo IoT de tipo válvula 4" (VALVE_4_ID) asociado al lote.
- Asigna automáticamente el predio a partir del lote.
- Valida que el usuario autenticado sea el dueño del predio del lote.
- Valida que el lote tenga una válvula 4" asociada.
- Valida que el caudal solicitado sea diferente al caudal actual del dispositivo.
- Mantiene la lógica de aprobación/rechazo solo para administradores.