### PR TITLE
feat(request): Añadir listar y detallar solicitudes

### DIFF
--- a/backend/communication/request/serializers.py
+++ b/backend/communication/request/serializers.py
@@ -198,3 +198,15 @@ class FlowActivationRequestStatusSerializer(BaseRequestStatusSerializer):
 
     class Meta(BaseRequestStatusSerializer.Meta):
         model = FlowActivationRequest
+
+
+class AllFlowRequestsSerializer(serializers.Serializer):
+    """Serializer para listar todas las solicitudes de caudal."""
+    id = serializers.IntegerField()
+    user = serializers.CharField(source='user.document')
+    lot = serializers.CharField(source='lot.id_lot')
+    plot = serializers.CharField()
+    status = serializers.CharField()
+    type = serializers.CharField()
+    created_at = serializers.DateTimeField()
+    reviewed_at = serializers.DateTimeField()

--- a/backend/communication/request/views.py
+++ b/backend/communication/request/views.py
@@ -1,14 +1,67 @@
-from rest_framework import generics
+from django.db import models
+from rest_framework import generics, status
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.response import Response
 from .models import FlowChangeRequest, FlowCancelRequest, FlowActivationRequest
 from .serializers import (FlowChangeRequestSerializer, FlowChangeRequestStatusSerializer, FlowCancelRequestSerializer,
-    FlowCancelRequestStatusSerializer, FlowActivationRequestSerializer, FlowActivationRequestStatusSerializer)
+    FlowCancelRequestStatusSerializer, FlowActivationRequestSerializer, FlowActivationRequestStatusSerializer, AllFlowRequestsSerializer)
+
 
 class FlowChangeRequestCreateView(generics.CreateAPIView):
     """Vista para crear solicitudes de cambio de caudal."""
     queryset = FlowChangeRequest.objects.all()
     serializer_class = FlowChangeRequestSerializer
     permission_classes = [IsAuthenticated]
+
+
+class FlowRequestsListView(generics.ListAPIView):
+    """Vista para listar todas las solicitudes de caudal."""
+    permission_classes = [IsAdminUser]
+    serializer_class = AllFlowRequestsSerializer
+
+    def get_queryset(self):
+        # Unir todas las solicitudes en una sola lista
+        change = FlowChangeRequest.objects.all().annotate(type=models.Value('Cambio', output_field=models.CharField()))
+        cancel = FlowCancelRequest.objects.all().annotate(type=models.Value('Cancelación', output_field=models.CharField()))
+        activate = FlowActivationRequest.objects.all().annotate(type=models.Value('Activación', output_field=models.CharField()))
+        # Unir los tres querysets
+        return list(change) + list(cancel) + list(activate)
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.get_queryset()
+        # Serializar manualmente
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
+
+
+class FlowRequestDetailView(generics.CreateAPIView):
+    """Vista para detallar solicitud de cambio de caudal."""
+    def get(self, request, tipo, pk):
+        model_map = {
+            'change': FlowChangeRequest,
+            'cancel': FlowCancelRequest,
+            'activate': FlowActivationRequest,
+        }
+        serializer_map = {
+            'change': FlowChangeRequestSerializer,
+            'cancel': FlowCancelRequestSerializer,
+            'activate': FlowActivationRequestSerializer,
+        }
+        model = model_map.get(tipo)
+        serializer_class = serializer_map.get(tipo)
+        if not model or not serializer_class:
+            return Response({'error': 'Tipo de solicitud no válido.'}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            instance = model.objects.get(pk=pk)
+        except model.DoesNotExist:
+            return Response({'error': 'Solicitud no encontrada.'}, status=status.HTTP_404_NOT_FOUND)
+
+        # Permitir solo al admin o al usuario dueño de la solicitud
+        if not (request.user.is_staff or instance.user == request.user):
+            return Response({'error': 'Solo el dueño del predio o el administrador puede detallar la solicitud de caudal de este lote.'}, status=status.HTTP_403_FORBIDDEN)
+        
+        serializer = serializer_class(instance)
+        return Response(serializer.data)
 
 class FlowChangeRequestStatusView(generics.UpdateAPIView):
     """Vista para actualizar el estado de la solicitud de cambio de caudal."""
@@ -17,11 +70,13 @@ class FlowChangeRequestStatusView(generics.UpdateAPIView):
     permission_classes = [IsAdminUser]
     lookup_field = 'pk'
 
+
 class FlowCancelRequestCreateView(generics.CreateAPIView):
     """Vista para crear solicitudes de cancelación de caudal."""
     queryset = FlowCancelRequest.objects.all()
     serializer_class = FlowCancelRequestSerializer
     permission_classes = [IsAuthenticated]
+
 
 class FlowCancelRequestStatusView(generics.UpdateAPIView):
     """Vista para actualizar el estado de la solicitud de cancelación de caudal."""
@@ -30,11 +85,13 @@ class FlowCancelRequestStatusView(generics.UpdateAPIView):
     permission_classes = [IsAdminUser]
     lookup_field = 'pk'
 
+
 class FlowActivationRequestCreateView(generics.CreateAPIView):
     """Vista para crear solicitudes de activación de caudal."""
     queryset = FlowActivationRequest.objects.all()
     serializer_class = FlowActivationRequestSerializer
     permission_classes = [IsAuthenticated]
+
 
 class FlowActivationRequestStatusView(generics.UpdateAPIView):
     """Vista para actualizar el estado de la solicitud de activación de caudal."""

--- a/backend/communication/urls.py
+++ b/backend/communication/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from communication.request.views import (FlowChangeRequestCreateView, FlowChangeRequestStatusView,
+from communication.request.views import (FlowChangeRequestCreateView, FlowRequestsListView, FlowRequestDetailView, FlowChangeRequestStatusView,
     FlowCancelRequestCreateView, FlowCancelRequestStatusView, FlowActivationRequestCreateView, FlowActivationRequestStatusView)
 from communication.reports.views import (
     WaterSupplyFailureReportCreateView,
@@ -8,7 +8,9 @@ from communication.reports.views import (
 from communication.application_report.views import ApplicationFailureReportCreateView
 
 urlpatterns = [
-    path('flow-change-request', FlowChangeRequestCreateView.as_view(), name='flow-change-request'), # Crear solicitud de cambio de caudal 
+    path('flow-change-request', FlowChangeRequestCreateView.as_view(), name='flow-change-request'), # Crear solicitud de cambio de caudal
+    path('flow-requests', FlowRequestsListView.as_view(), name='flow-requests'), # Listar todas las solicitudes de caudal (admin)
+    path('flow-requests/<str:tipo>/<int:pk>', FlowRequestDetailView.as_view(), name='detail-flow-request'), # Detallar solicitud de caudal
     path('flow-change-request/<int:pk>', FlowChangeRequestStatusView.as_view(), name='flow-change-request-status'), # Aprobar o rechazar solicitud de cambio de caudal (admin)
     path('flow-cancel-request', FlowCancelRequestCreateView.as_view(), name='flow-cancel-request'), # Crear solicitud de cancelación de caudal
     path('flow-cancel-request/<int:pk>', FlowCancelRequestStatusView.as_view(), name='flow-cancel-request-status'), # Aprobar o rechazar solicitud de cancelación de caudal (admin)


### PR DESCRIPTION
## Funcionalidades nuevas:
- Se agrega una vista para listar todas las solicitudes de caudal (cambio, cancelación y activación) en un solo endpoint: `'flow-requests`.
### Endpoint
![image](https://github.com/user-attachments/assets/c216822f-1759-4f91-a7ae-08a138a06f41)
### Salida
![image](https://github.com/user-attachments/assets/972a8202-8305-48ac-af65-06b10a82a1e7)

- Se implementa una vista para detallar cualquier solicitud de caudal, permitiendo ver la información completa de una solicitud específica según su tipo: `'flow-requests/<str:tipo>/<int:pk>'`.
### Endpoint
![image](https://github.com/user-attachments/assets/bd12a434-d4ec-46bd-ad5b-7872ccb00dbf)
Nota: Dependiendo del tipo de solicitud, se coloca: 'change', 'cancel' o 'activate'. En este caso, se detalló la solicitud tipo 'cancel'.
### Salida
![image](https://github.com/user-attachments/assets/f390320b-d028-4e9a-b0f8-13b148b098de)

- Solo el administrador o el usuario que realizó la solicitud puede acceder al detalle de la misma.
![image](https://github.com/user-attachments/assets/3cd4ea86-d434-4bd7-83c9-44c4812b536a)