### PR TITLE
feat(plots-lots): Desactivar todos los lotes si se desactiva el predio al cual pertenecen

### DIFF
--- a/backend/plots_lots/serializers.py
+++ b/backend/plots_lots/serializers.py
@@ -34,6 +34,12 @@ class LotSerializer(serializers.ModelSerializer):
         }
     )
 
+    def validate_is_activate(self, value):
+        ''' Valida que no se pueda activar un lote si su predio está desactivado '''
+        if self.plot.is_activate == False:
+            if value == True:
+                raise serializers.ValidationError("No se puede habilitar el lote si el predio al cual pertenece está deshabilitado.")
+
     class Meta:
         model = Lot
         fields = ['id_lot', 'plot', 'crop_name', 'crop_type', 'crop_variety', 'soil_type', 'is_activate', 'registration_date']


### PR DESCRIPTION
- Cada vez que se desactiva un predio, se desactivan todos sus lotes.
- Cuando se intenta activar un lote de un predio desactivado, salta una alerta de error: "No se puede habilitar el lote si el predio al cual pertenece está deshabilitado."
- Si se activa un predio que estaba desactivado anteriormente, todos sus lotes se activarán de forma automática.