### PR TITLE
feat(assignment): Retornar el valor del método validate_flow_request después de la validación

### DIFF
--- a/backend/communication/assigment_maintenance/serializers.py
+++ b/backend/communication/assigment_maintenance/serializers.py
@@ -26,7 +26,8 @@ class AssignmentSerializer(serializers.ModelSerializer):
         ''' Valida que no se permita crear una asignación de una solicitud que no debe ser delegada '''
         if value.requires_delegation == False:
             raise serializers.ValidationError({"error": "No se puede crear una asignación de esta solicitud."})
-        
+        return value
+
     def _validate_exclusive_assignment(self, data):
         flow_request = data.get('flow_request')
         failure_report = data.get('failure_report')


### PR DESCRIPTION
El problema está en que la validación validate_flow_request() está ejecutándose pero no está retornando el valor, lo que hace que cuando llegue a _validate_exclusive_assignment(), el campo flow_request sea None en el diccionario data.

Se resolvió el error.