### PR TITLE
Corregir lógica de validación de la longitud de las observaciones en solicitudes y reportes

### DIFF
--- a/backend/communication/reports/serializers.py
+++ b/backend/communication/reports/serializers.py
@@ -54,12 +54,8 @@ class FailureReportSerializer(serializers.ModelSerializer):
 
         # Validaciones específicas de APPLICATION_FAILURE
         if failure_type == TypeReport.APPLICATION_FAILURE:
-            print("failure_type == TypeReport.APPLICATION_FAILURE")
             if len(observations) < 10 or len(observations) > 200:
-                print("Las observaciones NO ESTÁN entre los 10 y 200 caracteres.")
                 raise serializers.ValidationError("Las observaciones deben estar entre los 10 y 200 caracteres.")
-            else: print("Las observaciones SÍ ESTÁN entre los 10 y 200 caracteres.")
-        else: print(failure_type != TypeReport.APPLICATION_FAILURE)
 
         # Validar predio activo
         if plot and not plot.is_activate:

--- a/backend/communication/reports/serializers.py
+++ b/backend/communication/reports/serializers.py
@@ -29,6 +29,7 @@ class FailureReportSerializer(serializers.ModelSerializer):
         failure_type = data.get('failure_type')
         status = data.get('status')
         observations = data.get('observations')
+        print(observations)
 
         # Validaciones heredadas de BaseRequestReport
         if lot:
@@ -53,8 +54,12 @@ class FailureReportSerializer(serializers.ModelSerializer):
 
         # Validaciones específicas de APPLICATION_FAILURE
         if failure_type == TypeReport.APPLICATION_FAILURE:
-            if len(observations) < 10 and len(observations) > 200:
+            print("failure_type == TypeReport.APPLICATION_FAILURE")
+            if len(observations) < 10 or len(observations) > 200:
+                print("Las observaciones NO ESTÁN entre los 10 y 200 caracteres.")
                 raise serializers.ValidationError("Las observaciones deben estar entre los 10 y 200 caracteres.")
+            else: print("Las observaciones SÍ ESTÁN entre los 10 y 200 caracteres.")
+        else: print(failure_type != TypeReport.APPLICATION_FAILURE)
 
         # Validar predio activo
         if plot and not plot.is_activate:

--- a/backend/communication/requests/serializers.py
+++ b/backend/communication/requests/serializers.py
@@ -159,11 +159,11 @@ class FlowRequestSerializer(serializers.ModelSerializer):
             if not observations:
                 raise serializers.ValidationError("El campo 'observations' es obligatorio.")
             if flow_request_type in {FlowRequestType.FLOW_TEMPORARY_CANCEL, FlowRequestType.FLOW_DEFINITIVE_CANCEL}:
-                if len(observations) < 5 and len(observations) > 200:
+                if len(observations) < 5 or len(observations) > 200:
                     raise serializers.ValidationError("Las observaciones deben estar entre los 5 y 200 caracteres.")
             elif flow_request_type == FlowRequestType.FLOW_ACTIVATION:
                 if len(observations) > 300:
-                    raise serializers.ValidationError("Las observaciones no pueden xceder los 300 caracteres.")
+                    raise serializers.ValidationError("Las observaciones no pueden exceder los 300 caracteres.")
 
     def validate_requires_delegation(self, value):
         if self.flow_request_type != FlowRequestType.FLOW_DEFINITIVE_CANCEL:


### PR DESCRIPTION
Se cambió el operador AND por OR para las validaciones: 

ANTES:
`if len(observations) < 5 and len(observations) > 200`

DESPUÉS :
`if len(observations) < 5 or len(observations) > 200`